### PR TITLE
Feature/misc css cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
     </header>
     <main class="bg-slate-300 flex flex-col justiy-center align-center h-full">
         <!-- section for rfc info -->
-        <section id="rfcContainer" class="border-4 border-gray-700 m-4">
+        <section id="rfcContainer" class="border-4 border-gray-700 m-4 max-w-screen-lg lg:mx-auto">
             <!-- to be dyn created by code in api-rfc.js-->
         </section>
         <!-- section for github info -->
-        <section id="githubContainer" class="border-4 border-gray-700 m-4">
+        <section id="githubContainer" class="border-4 border-gray-700 m-4 mx-w-screen-lg lg:mx-auto">
             <!-- to be dyn created by code in api-github.js-->
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="./assets/css/style.css" /> 
 </head>
 
-<body class="flex flex-col h-screen">
+<body class="flex flex-col h-screen bg-slate-300">
     <header class="text-white bg-gray-700 p-5 grid grid-cols-3 gap-4">
         <button id="historyButton" class="hover:bg-sky-700 border-2 p-2 justify-self-start">
             History

--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
 </head>
 
 <body class="flex flex-col h-screen bg-slate-300">
-    <header class="text-white bg-gray-700 p-5 grid grid-cols-3 gap-4">
+    <header class="text-white bg-gray-700 p-5 grid grid-cols-3">
         <button id="historyButton" class="hover:bg-sky-700 border-2 p-2 justify-self-start">
             History
         </button>
-        <h1 class="p-2 text-lg text-center grow">
+        <h1 class="p-2 text-lg sm:text-center grow col-span-2 sm:col-span-1">
             The Drunken RFC
         </h1>
     </header>

--- a/index.html
+++ b/index.html
@@ -26,9 +26,8 @@
             <!-- to be dyn created by code in api-rfc.js-->
         </section>
         <!-- section for github info -->
-        <section id="githubContainer" class="border-4 border-gray-700 m-4 h-full">
+        <section id="githubContainer" class="border-4 border-gray-700 m-4">
             <!-- to be dyn created by code in api-github.js-->
-            todo
         </section>
     </main>
     <!-- scripts -->

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
             The Drunken RFC
         </h1>
     </header>
-    <main class="bg-slate-300 flex flex-col justiy-center align-center h-full">
+    <main class="bg-slate-300 flex flex-col justiy-center align-center">
         <!-- section for rfc info -->
         <section id="rfcContainer" class="border-4 border-gray-700 m-4 max-w-screen-lg lg:mx-auto">
             <!-- to be dyn created by code in api-rfc.js-->

--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script src="./assets/js/saveload.js"></script>
     <script src="./assets/js/api-rfc.js"></script>
-    <script src="./assets/js/api-wikipedia.js"></script>
     <script src="./assets/js/api-github.js"></script>
     <script src="./assets/js/main-start.js"></script>
 </body>


### PR DESCRIPTION
This contains some styling cleanup on the main page.
- makes sure the background color is present if you have to scroll down.
- fixes the github container height so it adjusts to its content (and removes the default "todo" content)
- make header more responsive so it doesn't take up as much space on smaller devices